### PR TITLE
 Add initial AST types & parsing traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 [[package]]
 name = "nom"
 version = "4.0.0"
-source = "git+https://github.com/myrrlyn/nom?branch=2018-edition#77a9b16d3d64f18e0a7b1b74374ee469665b674a"
+source = "git+https://github.com/myrrlyn/nom?branch=2018-edition#f6b927b097dd86dbb7237c258da649030431edd2"
 dependencies = [
  "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/ast/builtin.rs
+++ b/src/ast/builtin.rs
@@ -1,0 +1,50 @@
+use std::{path::Path, str};
+
+use crate::ast;
+use crate::parse::{Parse, ParseError};
+
+/// Represents all shell builtins.
+#[derive(Clone, Debug)]
+pub enum Builtin<'a> {
+    Clear,
+    Cd(&'a Path),
+    WithEnv(WithEnv<'a>),
+    // TODO(eliza): add more!
+}
+
+#[derive(Clone, Debug, Fail)]
+pub enum CdError {
+    #[fail(display = "cd: no path provided")]
+    NoPath,
+}
+
+#[derive(Clone, Debug)]
+pub struct WithEnv<'a> {
+    cmd: ast::Cmd<'a>,
+    // TODO(eliza): what kind of fucked up iterator is the env going to be?
+}
+
+// ===== impl Builtin =====
+
+impl<'a> Parse<'a> for Builtin<'a> {
+    type Error = CdError;
+    fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
+        let mut args = s.trim().split_whitespace();
+        match args.next().ok_or(ParseError::NoInput)? {
+            "clear" => Ok(Builtin::Clear),
+            "cd" => {
+                let path = args.next().ok_or(CdError::NoPath)?;
+                Ok(Builtin::Cd(Path::new(path)))
+            }
+            _ => Err(ParseError::Unrecognized),
+        }
+    }
+}
+
+impl<'a> Parse<'a> for WithEnv<'a> {
+    type Error = ();
+    fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
+        // TODO(eliza): alex pls implement me
+        unimplemented!()
+    }
+}

--- a/src/ast/builtin.rs
+++ b/src/ast/builtin.rs
@@ -1,15 +1,17 @@
-use std::{path::Path, str};
-
-use crate::ast;
-use crate::parse::{Parse, ParseError};
+use std::{path::Path, str, rc::Rc};
+use failure::{
+    Fail,
+};
+use crate::{
+    ast,
+    parse::{Parse, ParseError},
+};
 
 /// Represents all shell builtins.
 #[derive(Clone, Debug)]
 pub enum Builtin<'a> {
     Clear,
     Cd(&'a Path),
-    WithEnv(WithEnv<'a>),
-    // TODO(eliza): add more!
 }
 
 #[derive(Clone, Debug, Fail)]
@@ -38,13 +40,5 @@ impl<'a> Parse<'a> for Builtin<'a> {
             }
             _ => Err(ParseError::Unrecognized),
         }
-    }
-}
-
-impl<'a> Parse<'a> for WithEnv<'a> {
-    type Error = ();
-    fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
-        // TODO(eliza): alex pls implement me
-        unimplemented!()
     }
 }

--- a/src/ast/invoke.rs
+++ b/src/ast/invoke.rs
@@ -1,0 +1,40 @@
+use std::{ffi::OsStr, fmt, iter, str};
+
+use crate::parse::{Parse, ParseError};
+
+/// Invocation of an executable command.
+///
+/// This is called `Invoke` because the name `Cmd` was already taken.
+#[derive(Clone, Debug)]
+pub struct Invoke<'a> {
+    /// The command to invoke.
+    pub command: &'a OsStr,
+    /// Zero or more arguments to pass to the command.
+    pub args: iter::Map<str::SplitWhitespace<'a>, fn(&'a str) -> &'a OsStr>,
+}
+
+// ===== impl Invoke =====
+
+impl<'a> Parse<'a> for Invoke<'a> {
+    type Error = ();
+    fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
+        // TODO(eliza): quoted args!
+        let mut args = s
+            .trim()
+            .split_whitespace()
+            .map(OsStr::new as fn(&'a str) -> &'a OsStr);
+        let command = args.next().ok_or(ParseError::NoInput)?;
+        let command = Invoke { command, args };
+        Ok(command)
+    }
+}
+
+impl<'a> fmt::Display for Invoke<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.command.to_string_lossy())?;
+        for ref arg in self.args.clone() {
+            write!(f, " {}", arg.to_string_lossy())?;
+        }
+        Ok(())
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -30,8 +30,8 @@ pub struct WithEnv<'a> {
 }
 
 impl<'a> Parse<'a> for Cmd<'a> {
-    type Error = ();
-    fn parse_from(s: &'a str) -> Result<Self, ParseError<()>> {
+    type Error = String; // placeholder
+    fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
         Builtin::parse_from(s)
             .map(Cmd::Builtin)
             .or_else(|_| Invoke::parse_from(s).map(Cmd::Invoke))
@@ -39,7 +39,7 @@ impl<'a> Parse<'a> for Cmd<'a> {
 }
 
 impl<'a> Parse<'a> for WithEnv<'a> {
-    type Error = ();
+    type Error = String; // placeholder
     fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
         // TODO(eliza): alex pls implement me
         unimplemented!()

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,0 +1,47 @@
+use std::str;
+
+use crate::parse::{Parse, ParseError};
+pub mod builtin;
+mod invoke;
+
+pub use self::builtin::Builtin;
+pub use self::invoke::Invoke;
+
+#[derive(Clone, Debug)]
+pub enum Cmd<'a> {
+    Builtin(builtin::Builtin<'a>),
+    Invoke(Invoke<'a>),
+}
+
+/// Evaluate a command in an environment.
+///
+/// This represents forms such as
+/// ```notrust
+/// FOO=foo BAR=bar command
+/// ```
+/// and
+/// ```notrust
+/// env FOO=foo BAR=bar command
+/// ```
+#[derive(Clone, Debug)]
+pub struct WithEnv<'a> {
+    cmd: Cmd<'a>,
+    // TODO(eliza): what kind of fucked up iterator is the env going to be?
+}
+
+impl<'a> Parse<'a> for Cmd<'a> {
+    type Error = ();
+    fn parse_from(s: &'a str) -> Result<Self, ParseError<()>> {
+        Builtin::parse_from(s)
+            .map(Cmd::Builtin)
+            .or_else(|_| Invoke::parse_from(s).map(Cmd::Invoke))
+    }
+}
+
+impl<'a> Parse<'a> for WithEnv<'a> {
+    type Error = ();
+    fn parse_from(s: &'a str) -> Result<Self, ParseError<Self::Error>> {
+        // TODO(eliza): alex pls implement me
+        unimplemented!()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,13 @@ use crossterm::{
 use std::io::Write;
 use duct::cmd;
 
-mod parse;
 mod ast;
 mod term;
 mod st;
 mod parse;
 
 use self::{
-    parse::{Parse, Span},
+    parse::Parse,
     ast::{Cmd, Builtin},
 };
 
@@ -66,30 +65,6 @@ fn run(mut screen: Screen) -> Result<(), Error> {
                     Ok(Cmd::Builtin(Builtin::Cd(_))) => unimplemented!("cd doesnt work yet"),
                     Ok(Cmd::Invoke(ref c)) => {
                         term::newline(&mut screen)?;
-
-
-                        //  args is a collection of &'line str snippets --
-                        //  pointers into the line buffer above
-                        let mut args: Vec<&str> = Vec::new();
-                        //  The command binding is used below, so we need a
-                        //  separate cursor for the tokenizing
-                        let mut text: &str = command;
-                        while text.len() > 0 {
-                            //  Use the span tokenizer to get a snippet
-                            let (rest, span) = span(text.into())
-                                //  Suppress the errors for now. May be worth
-                                //  investigating so that the shell can repont
-                                //  invalid syntax?
-                                .map_err(|_| failure::format_err!("Invalid text"))?;
-                                //  rest and span are CompleteStr, which implements
-                                //  Deref down to &str.
-                                args.push(*span);
-                                text = *rest;
-                        }
-                        if args.is_empty() {
-                            screen.flush()?;
-                            continue;
-                        }
                         cmd(c.command, c.args.clone())
                             .unchecked()
                             .stdout_capture()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,39 @@
+pub trait ParseInto<'a, T: Parse<'a>> {
+    fn parse_into(&'a self) -> Result<T, ParseError<T::Error>>;
+}
+
+/// Trait implemented by types which can be parsed from an `&'a str`.
+pub trait Parse<'a>: Sized {
+    type Error;
+    fn parse_from(input: &'a str) -> Result<Self, ParseError<Self::Error>>;
+}
+
+// TODO(eliza): add spans!
+#[derive(Clone, Debug, Fail)]
+pub enum ParseError<E: Fail> {
+    #[fail(display = "more input required")]
+    NoInput,
+    // TODO(eliza): would it be better to represent parse results as a
+    // Result<Option<T>,...> instead?
+    #[fail(display = "not recognized")]
+    Unrecognized,
+    Other(E),
+    // TODO(eliza): more variants: unrecognized character, too much input,
+    // etc...
+}
+
+impl<'a, T, P: 'a> ParseInto<'a, T> for P
+where
+    P: AsRef<str>,
+    T: Parse<'a>,
+{
+    fn parse_into(&'a self) -> Result<T, ParseError<T::Error>> {
+        T::parse_from(self.as_ref())
+    }
+}
+
+impl<E: Fail> From<E> for ParseError<E> {
+    fn from(err: E) -> ParseError<E> {
+        ParseError::Other(err)
+    }
+}

--- a/src/term.rs
+++ b/src/term.rs
@@ -11,6 +11,7 @@ use crossterm::{
     terminal::terminal,
     terminal::ClearType,
 };
+use std::fmt;
 use std::io::Write;
 use std::str;
 
@@ -37,7 +38,7 @@ pub fn backspace(screen: &mut Screen) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn not_found(screen: &mut Screen, command: &str) -> Result<(), Error> {
+pub fn not_found<C: fmt::Display>(screen: &mut Screen, command: &C) -> Result<(), Error> {
     screen.write(format!("ysh: command not found: {}", command).as_bytes())?;
     newline(screen)?;
     screen.flush()?;


### PR DESCRIPTION
This branch adds an initial set of types representing AST nodes in
the shell's command language. In addition, it defines traits for
parsing strings to AST nodes, and initial parsers for some of the basic
AST types.